### PR TITLE
Feature: pseudo installation of local package & install any branches/tags from any sites

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -46,12 +46,6 @@ func (c *Cli) ParseAndExec(args []string) error {
 
 	common := commonCmd{config: c.config, out: c.outWriter, err: c.errWriter, command: prog}
 	root := newRootCmd(common, c.version)
-	initializer := newInitCmd(common)
-	installer := newInstallCmd(common, c.git)
-	lister := newListCmd(common)
-	remover := newRemoveCmd(common)
-	upgrader := newUpgradeCmd(common, c.git)
-	destroyer := newDestroyCmd(common)
 
 	if len(args) == 1 {
 		root.flags.Usage()
@@ -60,16 +54,22 @@ func (c *Cli) ParseAndExec(args []string) error {
 
 	switch args[1] {
 	case "init":
+		initializer := newInitCmd(common)
 		return initializer.parseAndExec(args[2:])
 	case "install", "add":
+		installer := newInstallCmd(common, c.git)
 		return installer.parseAndExec(args[1:])
 	case "list":
+		lister := newListCmd(common)
 		return lister.parseAndExec(args[2:])
 	case "remove", "uninstall":
+		remover := newRemoveCmd(common)
 		return remover.parseAndExec(args[1:])
 	case "upgrade":
+		upgrader := newUpgradeCmd(common, c.git)
 		return upgrader.parseAndExec(args[2:])
 	case "destroy":
+		destroyer := newDestroyCmd(common)
 		return destroyer.parseAndExec(args[2:])
 	default:
 		return root.parseAndExec(args[1:])

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/progrhyme/shelp/internal/config"
 	"github.com/progrhyme/shelp/internal/git"
-	"github.com/spf13/pflag"
 )
 
 var (
@@ -71,28 +70,26 @@ func (c *Cli) ParseAndExec(args []string) error {
 	}
 }
 
-func parseStartHelp(
-	flags *pflag.FlagSet, option flagger, output io.Writer, args []string, requireArg bool,
-) (bool, error) {
+func parseStartHelp(cmd helpCommander, args []string, requireArg bool) (bool, error) {
 	if requireArg && len(args) == 0 {
-		flags.Usage()
+		cmd.flagset().Usage()
 		return true, ErrUsage
 	}
 
-	err := flags.Parse(args)
+	err := cmd.flagset().Parse(args)
 	if err != nil {
-		fmt.Fprintf(output, "Error! %s\n", err)
-		flags.Usage()
+		fmt.Fprintf(cmd.errs(), "Error! %s\n", err)
+		cmd.flagset().Usage()
 		return true, ErrParseFailed
 	}
 
-	if *option.helpFlg() {
-		flags.Usage()
+	if *cmd.getOpts().helpFlg() {
+		cmd.flagset().Usage()
 		return true, nil
 	}
 
-	if requireArg && flags.NArg() == 0 {
-		flags.Usage()
+	if requireArg && cmd.flagset().NArg() == 0 {
+		cmd.flagset().Usage()
 		return true, ErrUsage
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -29,14 +29,6 @@ type Cli struct {
 	errWriter io.Writer
 }
 
-type commonCmd struct {
-	config  config.Config
-	flags   pflag.FlagSet
-	out     io.Writer
-	err     io.Writer
-	command string
-}
-
 func NewCli(ver string, cfg config.Config, g git.Git, out, err io.Writer) Cli {
 	return Cli{version: ver, config: cfg, git: g, outWriter: out, errWriter: err}
 }
@@ -68,24 +60,15 @@ func (c *Cli) ParseAndExec(args []string) error {
 	case "upgrade":
 		upgrader := newUpgradeCmd(common, c.git)
 		return upgrader.parseAndExec(args[2:])
+	case "link":
+		linker := newLinkCmd(common)
+		return linker.parseAndExec(args[2:])
 	case "destroy":
 		destroyer := newDestroyCmd(common)
 		return destroyer.parseAndExec(args[2:])
 	default:
 		return root.parseAndExec(args[1:])
 	}
-}
-
-type flagger interface {
-	helpFlg() *bool
-}
-
-type commonFlags struct {
-	help *bool
-}
-
-func (flag *commonFlags) helpFlg() *bool {
-	return flag.help
 }
 
 func parseStartHelp(

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -50,7 +50,7 @@ Usage:`, prog),
 	commands["install"] = command{
 		true,
 		fmt.Sprintf(`Summary:
-  Install a repository in github.com as a %s package, assuming it contains shell scripts.
+  Install a repository from HTTPS site as a %s package, assuming it contains shell scripts.
 
 Syntax:`, prog),
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -79,6 +79,15 @@ Syntax:`,
 Syntax:`,
 	}
 
+	commands["link"] = command{
+		true,
+		`Summary:
+  Pseudo installation of a package from local filesystem.
+  Creates symbolic link of a directory into a package path.
+
+Syntax:`,
+	}
+
 	commands["destroy"] = command{
 		false,
 		fmt.Sprintf(`Summary:
@@ -209,6 +218,31 @@ PATH="%s:${PATH}"
 			[]string{prog, "list", "--no-such-option"},
 			ErrParseFailed, "",
 			strings.Join([]string{flagError, commands["list"].helpText}, "\n"),
+		},
+
+		// Subcommand "link"
+		{
+			[]string{prog, "link"},
+			ErrUsage, "", commands["link"].helpText,
+		},
+		{
+			[]string{prog, "link", "--help"},
+			nil, "", commands["link"].helpText,
+		},
+		{
+			[]string{prog, "link", "--no-such-option"},
+			ErrParseFailed, "",
+			strings.Join([]string{flagError, commands["link"].helpText}, "\n"),
+		},
+		{
+			[]string{prog, "link", "no/such/file/or/directory"},
+			ErrArgument, "",
+			"Error! \"no/such/file/or/directory\" does not exist\n",
+		},
+		{
+			[]string{prog, "link", ".", "-"},
+			ErrArgument, "",
+			"Error! Given argument \"-\" does not look like valid package name\n",
 		},
 
 		// Subcommand "destroy"

--- a/internal/cli/destroy.go
+++ b/internal/cli/destroy.go
@@ -18,6 +18,10 @@ type destroyCmd struct {
 	}
 }
 
+func (cmd *destroyCmd) getOpts() flagger {
+	return &cmd.option
+}
+
 func newDestroyCmd(common commonCmd) destroyCmd {
 	cmd := &destroyCmd{}
 	cmd.commonCmd = common
@@ -43,7 +47,7 @@ Options:
 }
 
 func (cmd *destroyCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, false)
+	done, err := parseStartHelp(cmd, args, false)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,12 +12,9 @@ import (
 )
 
 type initCmd struct {
-	commonCmd
+	helpCmd
 	shell  string
 	shProf string
-	option struct {
-		commonFlags
-	}
 }
 
 func newInitCmd(common commonCmd) initCmd {
@@ -81,7 +78,7 @@ Options:
 }
 
 func (cmd *initCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, true)
+	done, err := parseStartHelp(cmd, args, true)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -14,14 +14,9 @@ import (
 )
 
 type installCmd struct {
-	commonCmd
-	name   string
-	git    git.Git
-	option verboseFlags
-}
-
-func (cmd *installCmd) getOpts() verboseFlagger {
-	return &cmd.option
+	verboseCmd
+	name string
+	git  git.Git
 }
 
 func newInstallCmd(common commonCmd, git git.Git) installCmd {
@@ -63,7 +58,7 @@ func (cmd *installCmd) parseAndExec(args []string) error {
 	cmd.name = args[0]
 	cmd.flags.Usage = cmd.usage
 
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args[1:], true)
+	done, err := parseStartHelp(cmd, args[1:], true)
 	if done || err != nil {
 		return err
 	}
@@ -154,7 +149,7 @@ func createBinsLinks(cmd verboseCommander, path string) error {
 		if !file.IsDir() && isExecutable(file.Mode()) {
 			exe := filepath.Join(path, file.Name())
 			sym := filepath.Join(cmd.getConf().BinPath(), file.Name())
-			if *cmd.getOpts().verboseFlg() {
+			if *cmd.verboseOpts().verboseFlg() {
 				fmt.Fprintf(cmd.outs(), "Symlink: %s -> %s\n", sym, exe)
 			}
 			if _, err := os.Stat(sym); !os.IsNotExist(err) {

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/template"
+
+	"github.com/spf13/pflag"
+)
+
+type linkCmd struct {
+	commonCmd
+	option verboseFlags
+}
+
+func (cmd *linkCmd) getOpts() verboseFlagger {
+	return &cmd.option
+}
+
+func newLinkCmd(common commonCmd) linkCmd {
+	cmd := &linkCmd{}
+	cmd.commonCmd = common
+	cmd.flags = *pflag.NewFlagSet("link", pflag.ContinueOnError)
+
+	cmd.flags.SetOutput(cmd.err)
+	cmd.option.verbose = cmd.flags.BoolP("verbose", "v", false, "# Verbose output")
+	cmd.option.help = cmd.flags.BoolP("help", "h", false, "# Show help")
+	cmd.flags.Usage = cmd.usage
+	return *cmd
+}
+
+func (cmd *linkCmd) usage() {
+	const help = `Summary:
+  Pseudo installation of a package from local filesystem.
+  Creates symbolic link of a directory into a package path.
+
+Syntax:
+  {{.Prog}} {{.Cmd}} path/to/dir [<package-name>]
+
+If you ommit "<package-name>" argument, the basename of the directory is used as the package name.
+
+Examples:
+  {{.Prog}} {{.Cmd}} .                   # Link current directory
+  {{.Prog}} {{.Cmd}} path/to/foo-sh foo  # Link as package "foo"
+
+Options:
+`
+
+	t := template.Must(template.New("usage").Parse(help))
+	t.Execute(cmd.err, struct{ Prog, Cmd string }{cmd.command, "link"})
+
+	cmd.flags.PrintDefaults()
+}
+
+func (cmd *linkCmd) parseAndExec(args []string) error {
+	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, true)
+	if done || err != nil {
+		return err
+	}
+
+	src := cmd.flags.Arg(0)
+	if _, err := os.Stat(src); os.IsNotExist(err) {
+		fmt.Fprintf(cmd.err, "Error! \"%s\" does not exist\n", src)
+		return ErrArgument
+	}
+	path, err := filepath.Abs(src)
+	if err != nil {
+		fmt.Fprintf(cmd.err, "Error! Can't resolve path of \"%s\"\n", src)
+		return ErrArgument
+	}
+	base := filepath.Base(path)
+
+	if err = prepareInstallDirectories(cmd.config); err != nil {
+		fmt.Fprintf(cmd.err, "Error! %s\n", err)
+		return ErrOperationFailed
+	}
+
+	var pkg string
+	if cmd.flags.NArg() > 1 {
+		re := regexp.MustCompile(`^\w+`)
+		if !re.MatchString(cmd.flags.Arg(1)) {
+			fmt.Fprintf(
+				cmd.err,
+				"Error! Given argument \"%s\" does not look like valid package name\n",
+				cmd.flags.Arg(1))
+			return ErrArgument
+		}
+		pkg = cmd.flags.Arg(1)
+	} else {
+		pkg = base
+	}
+	pkgPath := filepath.Join(cmd.config.PackagePath(), pkg)
+	if _, err := os.Stat(pkgPath); !os.IsNotExist(err) {
+		fmt.Fprintf(cmd.err, "\"%s\" is already installed\n", pkg)
+		return ErrArgument
+	}
+
+	if err = os.Symlink(path, pkgPath); err != nil {
+		fmt.Fprintf(cmd.err, "Error! %s\n", err)
+		return ErrOperationFailed
+	}
+
+	binPath := filepath.Join(pkgPath, "bin")
+	var linkErr error
+	if _, err := os.Stat(binPath); err == nil {
+		linkErr = createBinsLinks(cmd, binPath)
+	} else {
+		linkErr = createBinsLinks(cmd, pkgPath)
+	}
+	if linkErr != nil {
+		fmt.Fprintf(cmd.err, "\"%s\" is linked as package \"%s\", but with some failures\n", src, pkg)
+		return linkErr
+	}
+
+	fmt.Fprintf(cmd.out, "\"%s\" is linked as package \"%s\"\n", src, pkg)
+	return nil
+}

--- a/internal/cli/link.go
+++ b/internal/cli/link.go
@@ -11,12 +11,7 @@ import (
 )
 
 type linkCmd struct {
-	commonCmd
-	option verboseFlags
-}
-
-func (cmd *linkCmd) getOpts() verboseFlagger {
-	return &cmd.option
+	verboseCmd
 }
 
 func newLinkCmd(common commonCmd) linkCmd {
@@ -55,7 +50,7 @@ Options:
 }
 
 func (cmd *linkCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, true)
+	done, err := parseStartHelp(cmd, args, true)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -9,11 +9,7 @@ import (
 )
 
 type listCmd struct {
-	commonCmd
-	option struct {
-		verbose *bool
-		commonFlags
-	}
+	verboseCmd
 }
 
 func newListCmd(common commonCmd) listCmd {
@@ -41,7 +37,7 @@ Options:
 }
 
 func (cmd *listCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, false)
+	done, err := parseStartHelp(cmd, args, false)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -12,12 +12,8 @@ import (
 )
 
 type removeCmd struct {
-	commonCmd
-	name   string
-	option struct {
-		verbose *bool
-		commonFlags
-	}
+	verboseCmd
+	name string
 }
 
 func newRemoveCmd(common commonCmd) removeCmd {
@@ -55,7 +51,7 @@ func (cmd *removeCmd) parseAndExec(args []string) error {
 	cmd.name = args[0]
 	cmd.flags.Usage = cmd.usage
 
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args[1:], true)
+	done, err := parseStartHelp(cmd, args[1:], true)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -45,6 +45,7 @@ Available Commands:
   uninstall  # Alias of "remove"
   list       # List installed packages
   upgrade    # Upgrade an installed package
+  link       # Pseudo installation of local directory
   destroy    # Delete all materials including packages
 
 Run "{{.Prog}} COMMAND -h|--help" to see usage of each command.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,10 @@ type rootCmd struct {
 	}
 }
 
+func (cmd *rootCmd) getOpts() flagger {
+	return &cmd.option
+}
+
 func newRootCmd(common commonCmd, ver string) rootCmd {
 	cmd := &rootCmd{version: ver}
 	cmd.commonCmd = common
@@ -60,7 +64,7 @@ Options without subcommand:
 }
 
 func (cmd *rootCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, false)
+	done, err := parseStartHelp(cmd, args, false)
 	if done || err != nil {
 		return err
 	}

--- a/internal/cli/types.go
+++ b/internal/cli/types.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/progrhyme/shelp/internal/config"
+	"github.com/spf13/pflag"
+)
+
+type flagger interface {
+	helpFlg() *bool
+}
+
+type commander interface {
+	getConf() *config.Config
+	outs() io.Writer
+	errs() io.Writer
+}
+
+type verboseFlagger interface {
+	flagger
+	verboseFlg() *bool
+}
+
+type verboseCommander interface {
+	commander
+	getOpts() verboseFlagger
+}
+
+// Meets commander interface
+type commonCmd struct {
+	config  config.Config
+	flags   pflag.FlagSet
+	out     io.Writer
+	err     io.Writer
+	command string
+}
+
+func (cmd *commonCmd) getConf() *config.Config {
+	return &cmd.config
+}
+
+func (cmd *commonCmd) outs() io.Writer {
+	return cmd.out
+}
+
+func (cmd *commonCmd) errs() io.Writer {
+	return cmd.err
+}
+
+type commonFlags struct {
+	help *bool
+}
+
+func (flag *commonFlags) helpFlg() *bool {
+	return flag.help
+}
+
+type verboseFlags struct {
+	commonFlags
+	verbose *bool
+}
+
+func (flag *verboseFlags) verboseFlg() *bool {
+	return flag.verbose
+}

--- a/internal/cli/types.go
+++ b/internal/cli/types.go
@@ -7,24 +7,11 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type flagger interface {
-	helpFlg() *bool
-}
-
 type commander interface {
 	getConf() *config.Config
+	flagset() *pflag.FlagSet
 	outs() io.Writer
 	errs() io.Writer
-}
-
-type verboseFlagger interface {
-	flagger
-	verboseFlg() *bool
-}
-
-type verboseCommander interface {
-	commander
-	getOpts() verboseFlagger
 }
 
 // Meets commander interface
@@ -40,12 +27,20 @@ func (cmd *commonCmd) getConf() *config.Config {
 	return &cmd.config
 }
 
+func (cmd *commonCmd) flagset() *pflag.FlagSet {
+	return &cmd.flags
+}
+
 func (cmd *commonCmd) outs() io.Writer {
 	return cmd.out
 }
 
 func (cmd *commonCmd) errs() io.Writer {
 	return cmd.err
+}
+
+type flagger interface {
+	helpFlg() *bool
 }
 
 type commonFlags struct {
@@ -56,6 +51,25 @@ func (flag *commonFlags) helpFlg() *bool {
 	return flag.help
 }
 
+type helpCommander interface {
+	commander
+	getOpts() flagger
+}
+
+type helpCmd struct {
+	commonCmd
+	option commonFlags
+}
+
+func (cmd *helpCmd) getOpts() flagger {
+	return &cmd.option
+}
+
+type verboseFlagger interface {
+	flagger
+	verboseFlg() *bool
+}
+
 type verboseFlags struct {
 	commonFlags
 	verbose *bool
@@ -63,4 +77,22 @@ type verboseFlags struct {
 
 func (flag *verboseFlags) verboseFlg() *bool {
 	return flag.verbose
+}
+
+type verboseCommander interface {
+	commander
+	verboseOpts() verboseFlagger
+}
+
+type verboseCmd struct {
+	commonCmd
+	option verboseFlags
+}
+
+func (cmd *verboseCmd) getOpts() flagger {
+	return &cmd.option
+}
+
+func (cmd *verboseCmd) verboseOpts() verboseFlagger {
+	return &cmd.option
 }

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -11,12 +11,8 @@ import (
 )
 
 type upgradeCmd struct {
-	commonCmd
-	git    git.Git
-	option struct {
-		verbose *bool
-		commonFlags
-	}
+	verboseCmd
+	git git.Git
 }
 
 func newUpgradeCmd(common commonCmd, git git.Git) upgradeCmd {
@@ -52,7 +48,7 @@ Options:
 }
 
 func (cmd *upgradeCmd) parseAndExec(args []string) error {
-	done, err := parseStartHelp(&cmd.flags, &cmd.option, cmd.err, args, true)
+	done, err := parseStartHelp(cmd, args, true)
 	if done || err != nil {
 		return err
 	}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -23,11 +23,15 @@ func NewGit(out, err io.Writer) Git {
 	return Git{cmd: cmd, out: out, err: err, shallow: true}
 }
 
-func (g *Git) Clone(src, dst string, verbose bool) error {
-	args := []string{"clone", src, dst}
+func (g *Git) Clone(src, dst string, branch string, verbose bool) error {
+	args := []string{"clone", src}
+	if branch != "" {
+		args = append(args, fmt.Sprintf("--branch=%s", branch))
+	}
 	if g.shallow {
 		args = append(args, "--depth=1")
 	}
+	args = append(args, dst)
 	return g.prepareCommand(args, verbose).Run()
 }
 


### PR DESCRIPTION
Features:

- Add `link` subcommand: pseudo installation from local filesystems; creating symbolic link to original resource
- (install) Enable to install from any git hosting sites which provides HTTPS protocol: e.g. bitbucket.org, gitlab.com
- (install) Enable to specify git branch or tag to clone by adding `@<branch-or-tag>` suffix to the argument
