### PR TITLE
Enhance: install repository and checkout specified commit hash 

### DIFF
--- a/internal/cli/fileutil.go
+++ b/internal/cli/fileutil.go
@@ -17,3 +17,16 @@ func isSymlink(path string, errs io.Writer) bool {
 	}
 	return false
 }
+
+func chdir(cmd runner, path string) (pwd string, err error) {
+	pwd, err = os.Getwd()
+	if err != nil {
+		fmt.Fprintln(cmd.getErrs(), "Error! Can't get current directory")
+		return
+	}
+	if err = os.Chdir(path); err != nil {
+		fmt.Fprintf(cmd.getErrs(), "Error! Directory change failed. Path = %s\n", path)
+		return
+	}
+	return
+}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -150,12 +150,8 @@ func packageToInstall(cmd verboseRunner, args installArgs) (shelpkg, error) {
 
 func packageInstalled(cmd gitRunner, path string) (shelpkg, error) {
 	pkg := shelpkg{}
-	pwd, err := os.Getwd()
+	pwd, err := chdir(cmd, path)
 	if err != nil {
-		fmt.Fprintln(cmd.getErrs(), "Error! Can't get current directory")
-	}
-	if err := os.Chdir(path); err != nil {
-		fmt.Fprintf(cmd.getErrs(), "Error! Directory change failed. Path = %s\n", path)
 		return pkg, ErrOperationFailed
 	}
 	defer os.Chdir(pwd)

--- a/internal/cli/outdated.go
+++ b/internal/cli/outdated.go
@@ -85,9 +85,11 @@ func hasPackageUpdate(cmd gitRunner, name string) (bool, error) {
 		return false, nil
 	}
 
-	if err := os.Chdir(path); err != nil {
-		fmt.Fprintf(cmd.getErrs(), "Error! Directory change failed. Path = %s\n", path)
+	pwd, err := chdir(cmd, path)
+	if err != nil {
 		return false, ErrOperationFailed
 	}
+	defer os.Chdir(pwd)
+
 	return cmd.getGit().HasUpdate(*cmd.getVerboseOpts().getVerbose())
 }

--- a/internal/cli/shelpkg.go
+++ b/internal/cli/shelpkg.go
@@ -6,6 +6,7 @@ type shelpkg struct {
 	url             string
 	ref             string
 	isBranchDefault bool
+	isCommitHash    bool
 }
 
 func (pkg *shelpkg) isEquivalent(tgt shelpkg) bool {

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -67,7 +67,17 @@ func (cmd *upgradeCmd) upgradeOne(pkg string) error {
 	}
 	defer os.Chdir(pwd)
 
-	err := cmd.git.Pull(*cmd.option.verbose)
+	hasUpdate, err := cmd.git.HasUpdate(*cmd.option.verbose)
+	if err != nil {
+		return ErrCommandFailed
+	}
+
+	if !hasUpdate {
+		fmt.Fprintln(cmd.outs, "No need to upgrade")
+		return nil
+	}
+
+	err = cmd.git.Pull(*cmd.option.verbose)
 	if err != nil {
 		return ErrCommandFailed
 	}

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -61,10 +61,11 @@ func (cmd *upgradeCmd) upgradeOne(pkg string) error {
 		return ErrArgument
 	}
 
-	if err := os.Chdir(path); err != nil {
-		fmt.Fprintf(cmd.errs, "Error! Directory change failed. Path = %s\n", path)
+	pwd, err := chdir(cmd, path)
+	if err != nil {
 		return ErrOperationFailed
 	}
+	defer os.Chdir(pwd)
 
 	err := cmd.git.Pull(*cmd.option.verbose)
 	if err != nil {


### PR DESCRIPTION
Enhance:

- (install) Support to specify commit hash of repository on installation

Other:

- (internal change) Always move back to original directory after some operations changing directory; `upgrade` and `outdated`